### PR TITLE
Specify "tracts" to avoid readOGR error

### DIFF
--- a/R/tracts.R
+++ b/R/tracts.R
@@ -1,3 +1,3 @@
-tracts <- readOGR(dsn="data/geojson/tracts.geojson", layer="OGRGeoJSON",
+tracts <- readOGR(dsn="data/geojson/tracts.geojson", layer="tracts",
                   stringsAsFactors = FALSE)
 tracts <- spTransform(tracts, CRS("+init=epsg:4326"))


### PR DESCRIPTION
When running this file, will encounter `Cannot open layer` error. Looks like the `layer` option was incorrect. This will be able to read the file.